### PR TITLE
Modified to take custom git arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,39 @@ Install and add to dependencies:
 npm install grunt-update-submodules --save-dev
 ```
 
-Use `update_submodules` in your task definitions!
+Use `update_submodules` and initialize it:
+###Basic Initialization
+```javascript
+grunt.initConfig({
+	"update_submodules": {
+		default: {
+			options: {
+				// don't specify a gitArgs so the default arguments will be used: git submodule update --init --recursive
+			}
+		}
+	}
+});
+```
+
+###Custom/Blank Arguments
+You can have your own custom `git submodule update` arguments by defining the `gitArgs` option in your task target.
+e.g.
+```javascript
+grunt.initConfig({
+	"update_submodules": {
+		withCustomArgs: {
+			options: {
+				gitArgs: "--force" // specify your own git arguments
+			}
+		},
+		withBlankArgs: {
+			options: {
+				gitArgs: null // using null or '' will result to blank git arguments
+			}
+		}
+	}
+});
+```
 
 ## License
 Copyright (c) 2012 - 2014 Julian Aubourg <j@ubourg.net>

--- a/lib/register.js
+++ b/lib/register.js
@@ -3,9 +3,7 @@
 module.exports = function( task ) {
 
 	return function( grunt ) {
-
-		grunt.registerTask( task.name, function() {
-
+		grunt.registerMultiTask( task.name, function() {
 			var done = this.async();
 
 			var runner = {
@@ -47,7 +45,9 @@ module.exports = function( task ) {
 
 			runner.log( task.display + "..." );
 
-			task.run( runner );
+			var options = this.options();
+
+			task.run( runner, options );
 
 		} );
 	};

--- a/lib/task.js
+++ b/lib/task.js
@@ -6,14 +6,13 @@ module.exports = {
 
 	display: "Updating submodules",
 
-	run: function( runner ) {
+	run: function( runner, options ) {
 
 		runner.exec( "git submodule", function( result ) {
-
 			var merge =  /(?:^|\n)-/.test( result.stdout ) ? "" : " --merge";
-
-			runner.exec( "git submodule update --init --recursive" + merge, runner.ok );
-
+			var gitArgs = options.hasOwnProperty( "gitArgs" ) ? options.gitArgs || "" : "--init --recursive" + merge;
+			var command = "git submodule update " + gitArgs;
+			runner.exec( command.trim(), runner.ok );
 		} );
 
 	}

--- a/test/data/Gruntfile.js
+++ b/test/data/Gruntfile.js
@@ -2,9 +2,30 @@
 
 module.exports = function( grunt ) {
 
-	grunt.registerTask( "default", "update_submodules" );
+	grunt.initConfig({
+		"update_submodules": {
+			default: {
+				options: {
+					// gitArgs: undefined // really commented to have this undefined
+				}
+			},
+			withCustomArgs: {
+				options: {
+					gitArgs: "--force"
+				}
+			},
+			withBlankArgs: {
+				options: {
+					gitArgs: null
+				}
+			}
+		}
+	});
 
 	// Load tasks
 	grunt.loadTasks( "../../tasks" );
 
+	grunt.registerTask( "default", "update_submodules" );
+	grunt.registerTask( "withArgs", "update_submodules:withCustomArgs" );
+	grunt.registerTask( "blankArgs", "update_submodules:withBlankArgs" );
 };

--- a/test/unit.js
+++ b/test/unit.js
@@ -149,6 +149,64 @@ module.exports = {
 			} );
 
 		} );
+	},
+
+	"test with custom git args": function( _ ) {
+
+		_.expect( 1 );
+
+		var expectedCommand = "\ngit submodule update --force";
+
+		createGitDir( "customGitArgs", [ {
+
+			folder: "grunt-update-submodules",
+			url: "https://github.com/jaubourg/grunt-update-submodules.git"
+
+		}, {
+
+			folder: "jquery-deferred-for-node",
+			url: "https://github.com/jaubourg/jquery-deferred-for-node.git"
+
+		} ], function( done ) {
+
+			exec( "grunt withArgs --verbose --no-color", function( stdout ) {
+
+				_.ok( stdout.indexOf( expectedCommand + "\n" ) > 0, "Command with custom git arguments" );
+
+				done();
+				_.done();
+			} );
+
+		} );
+	},
+
+	"test with blank git args": function( _ ) {
+
+		_.expect( 1 );
+
+		var expectedCommand = "\ngit submodule update";
+
+		createGitDir( "blankArgs", [ {
+
+			folder: "grunt-update-submodules",
+			url: "https://github.com/jaubourg/grunt-update-submodules.git"
+
+		}, {
+
+			folder: "jquery-deferred-for-node",
+			url: "https://github.com/jaubourg/jquery-deferred-for-node.git"
+
+		} ], function( done ) {
+
+			exec( "grunt blankArgs --verbose --no-color", function( stdout ) {
+
+				_.ok( stdout.indexOf( expectedCommand + "\n" ) > 0, "Command with custom git arguments" );
+
+				done();
+				_.done();
+			} );
+
+		} );
 	}
 
 };


### PR DESCRIPTION
- made it multitask so user can specify own targets
- custom git submodule update arguments can now be used by defining an
  option called `gitArgs` for your task target
- if `gitArgs` option is not defined, arguments will still fallback to
  the original `"--init --recursive" + merge` one.
- if `gitArgs` option is `null`, no arguments will be used, which will
  be just `git submodule update`
